### PR TITLE
Add aws-okta to custom tap

### DIFF
--- a/Formula/aws-okta.rb
+++ b/Formula/aws-okta.rb
@@ -1,3 +1,7 @@
+# Why is this here?
+# Using the upstream aws-okta formula, people aren't able install aws-okta anymore. This fork
+# will allow people to install aws-okta by brew install gusto/gusto/aws-okta
+# See https://github.com/segmentio/aws-okta/issues/278 for upstream notification
 class AwsOkta < Formula
   desc "Authenticate with AWS using your Okta credentials"
   homepage "https://github.com/segmentio/aws-okta"


### PR DESCRIPTION
This is a direct copy from [upstream][1] with the deprecation removed.

Using the upstream aws-okta formula, people aren't able install aws-okta anymore. This fork
will allow people to install aws-okta by `brew install gusto/gusto/aws-okta`.

[Private Bug Report][2]

  [1]: https://github.com/Homebrew/homebrew-core/blob/HEAD/Formula/aws-okta.rb
  [2]: https://gustohq.slack.com/archives/CM6TG0J8K/p1661510656659469