### PR TITLE
upgrade packs formula (from 0.1.80 to 0.1.85)

### DIFF
--- a/Formula/packs.rb
+++ b/Formula/packs.rb
@@ -4,7 +4,7 @@
 class Packs < Formula
   desc "A pure Rust implementation of packwerk, a gradual modularization tool for Ruby"
   homepage "https://github.com/alexevanczuk/packs"
-  url "https://github.com/alexevanczuk/packs/releases/download/v0.1.80/packs-mac.tar.gz"
+  url "https://github.com/alexevanczuk/packs/releases/download/v0.1.85/packs-mac.tar.gz"
   sha256 "f7b1dd465b8f79b67dd83e5cf0dc868a24fdc028c8ce219138e1775a8afa7239"
   license "MIT"
 

--- a/Formula/packs.rb
+++ b/Formula/packs.rb
@@ -2,7 +2,7 @@
 # frozen_string_literal: true
 
 class Packs < Formula
-  desc "A pure Rust implementation of packwerk, a gradual modularization tool for Ruby"
+  desc "Pure Rust implementation of packwerk, a gradual modularization tool for Ruby"
   homepage "https://github.com/alexevanczuk/packs"
   url "https://github.com/alexevanczuk/packs/releases/download/v0.1.85/packs-mac.tar.gz"
   sha256 "f7b1dd465b8f79b67dd83e5cf0dc868a24fdc028c8ce219138e1775a8afa7239"

--- a/Formula/packs.rb
+++ b/Formula/packs.rb
@@ -5,7 +5,7 @@ class Packs < Formula
   desc "Pure Rust implementation of packwerk, a gradual modularization tool for Ruby"
   homepage "https://github.com/alexevanczuk/packs"
   url "https://github.com/alexevanczuk/packs/releases/download/v0.1.85/packs-mac.tar.gz"
-  sha256 "f7b1dd465b8f79b67dd83e5cf0dc868a24fdc028c8ce219138e1775a8afa7239"
+  sha256 "6258fc183c1f71f24007dac6deffe58cbf18d40120ec99b937ce97f000fff50d"
   license "MIT"
 
   def install


### PR DESCRIPTION
Updating to the latest `pks` release

* [Release v0.1.85 · alexevanczuk/packs](https://github.com/alexevanczuk/packs/releases/tag/v0.1.85)
* [Change log](https://github.com/alexevanczuk/packs/compare/v0.1.80...v0.1.85)