### PR TITLE
Adds Local Development Instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,19 @@ tap "gusto/gusto", "git@github.com:Gusto/homebrew-gusto.git"
 brew "<formula>"
 ```
 
+## How to develop locally
+
+Create symlink to Taps directory
+```
+ln -s /path/to/local/homebrew-gusto `brew --repo`/Library/Taps/gusto/homebrew-gustotest
+```
+
+Install local formula
+```
+brew install gusto/gustotest/<formula>
+```
+
+
 ## Documentation
 
 `brew help`, `man brew` or check [Homebrew's documentation](https://docs.brew.sh).

--- a/README.md
+++ b/README.md
@@ -34,7 +34,6 @@ Install local formula
 brew install gusto/gustotest/<formula>
 ```
 
-
 ## Documentation
 
 `brew help`, `man brew` or check [Homebrew's documentation](https://docs.brew.sh).


### PR DESCRIPTION
Their isn’t support from homebrew to  tap a local repo. Since taps are jsut located in the` /opt/homebrew/Library/Taps/`  we can create a symlink to your local repo to test out our changes: 
```
ln -s ~/workspace/homebrew-gusto `brew --repo`/Library/Taps/gusto/homebrew-gustotest
```

Now we can test our service` brew services start <my-service>` and install local formulas ` brew install gusto/gustotest/formula`