### PR TITLE
Adds a Gusto managed Colima Brew Service

### DIFF
--- a/Formula/gusto-lima.rb
+++ b/Formula/gusto-lima.rb
@@ -2,7 +2,7 @@ class GustoLima < Formula
   desc "Gusto's opinionated colima profile"
   homepage "https://github.com/abiosoft/colima/blob/main/README.md"
   url "https://github.com/abiosoft/colima.git",
-      tag:      "v0.1.0"
+    tag:      "v0.1.0"
   license "MIT"
   head "https://github.com/abiosoft/colima.git", branch: "main"
 

--- a/Formula/gusto-lima.rb
+++ b/Formula/gusto-lima.rb
@@ -1,11 +1,12 @@
 class GustoLima < Formula
-  desc "Gusto's Colima Brew Service"
+  desc "Gusto's opinionated colima profile"
   homepage "https://github.com/abiosoft/colima/blob/main/README.md"
-  url "https://github.com/gusto/homebrew-gusto.git", tag: "v0.1.0"
+  url "https://github.com/gusto/homebrew-gusto.git"
+  sha256 "6df73ae5c606c298d91fcb4f6aa6b3b451082c4a"
 
   depends_on "colima"
   depends_on "docker"
-  depends_on "docker-buildx"
+  depends_on "docker-buildx" 
   depends_on "docker-compose"
   depends_on "docker-credential-helper"
   depends_on "docker-credential-helper-ecr"

--- a/Formula/gusto-lima.rb
+++ b/Formula/gusto-lima.rb
@@ -2,7 +2,7 @@ class GustoLima < Formula
   desc "Gusto's Colima Brew Service"
   homepage "https://github.com/abiosoft/colima/blob/main/README.md"
   url "https://github.com/gusto/homebrew-gusto.git", branch: "main"
-  version "0.1.0" 
+  version "0.1.0"
 
   depends_on "colima"
   depends_on "docker"

--- a/Formula/gusto-lima.rb
+++ b/Formula/gusto-lima.rb
@@ -24,7 +24,8 @@ class GustoLima < Formula
     ]
     system "go", "build", *std_go_args(ldflags:), "./cmd/colima"
 
-    bin.install_symlink opt_bin/"colima" => "colima@0.6.8"
+    bin.install_symlink bin/"gusto-lima" => bin/"colima"
+
     gusto_profile_config = <<~YAML
       cpu: 4
       disk: 60
@@ -63,7 +64,7 @@ class GustoLima < Formula
   end
 
   service do
-    run [opt_bin/"colima@0.6.8", "start", "-f", "gusto"]
+    run [opt_bin/"gusto-lima", "start", "-f", "gusto"]
     keep_alive successful_exit: true
     environment_variables PATH: std_service_path_env
     error_log_path var/"log/gusto.log"
@@ -72,7 +73,7 @@ class GustoLima < Formula
   end
 
   test do
-    assert_match version.to_s, shell_output("#{bin}/colima@0.6.8 version 2>&1")
-    assert_match "colima@0.6.8 is not running", shell_output("#{bin}/colima@0.6.8 status 2>&1", 1)
+    assert_match version.to_s, shell_output("#{bin}/gusto-lima version 2>&1")
+    assert_match "gusto-lima is not running", shell_output("#{bin}/gusto-lima status 2>&1", 1)
   end
 end

--- a/Formula/gusto-lima.rb
+++ b/Formula/gusto-lima.rb
@@ -25,7 +25,6 @@ class GustoLima < Formula
   end
 
   test do
-    assert_match version.to_s, shell_output("#{bin}/gusto-lima version 2>&1")
-    assert_match "gusto-lima is not running", shell_output("#{bin}/gusto-lima status 2>&1", 1)
+    assert_match "colima is not running", shell_output("#{bin}/gusto-lima status 2>&1", 1)
   end
 end

--- a/Formula/gusto-lima.rb
+++ b/Formula/gusto-lima.rb
@@ -2,7 +2,7 @@ class GustoLima < Formula
   desc "Gusto's opinionated colima profile"
   homepage "https://github.com/abiosoft/colima/blob/main/README.md"
   url "https://github.com/abiosoft/colima.git",
-      tag:      "v0.1.0",
+      tag:      "v0.1.0"
   license "MIT"
   head "https://github.com/abiosoft/colima.git", branch: "main"
 

--- a/Formula/gusto-lima.rb
+++ b/Formula/gusto-lima.rb
@@ -14,44 +14,7 @@ class GustoLima < Formula
   depends_on "docker-credential-helper-ecr"
 
   def install
-
-    bin.install_symlink "/opt/homebrew/opt/colima/bin/colima" => "gusto-lima"
-
-    gusto_profile_config = <<~YAML
-      cpu: 4
-      disk: 60
-      memory: 8
-      arch: host
-      runtime: docker
-      hostname: ""
-      kubernetes:
-      enabled: false
-      version: v1.24.3+k3s1
-      k3sArgs:
-        - --disable=traefik
-      autoActivate: true
-      network:
-      address: false
-      dnsHosts:
-        host.docker.internal: host.lima.internal
-      forwardAgent: false
-      docker: {}
-      vmType: vz
-      rosetta: false
-      mountType: virtiofs
-      mountInotify: false
-      cpuType: host
-      provision:
-        - mode: system
-          script: sysctl -w vm.max_map_count=262144
-      sshConfig: true
-      mounts: []
-      env: {}
-    YAML
-
-    colima_profile_path = Pathname.new(Dir.home)/".colima/gusto"
-    colima_profile_path.mkpath
-    File.write(colima_profile_path/"colima.yaml", gusto_profile_config)
+    bin.install "colima" => "gusto-lima"
   end
 
   service do

--- a/Formula/gusto-lima.rb
+++ b/Formula/gusto-lima.rb
@@ -1,7 +1,7 @@
 class GustoLima < Formula
   desc "Gusto's Colima Brew Service"
   homepage "https://github.com/abiosoft/colima/blob/main/README.md"
-  url "https://github.com/abiosoft/colima.git", tag: "v0.6.8"
+  url "https://github.com/abiosoft/colima.git", tag: "v0.1.1"
 
   depends_on "colima"
   depends_on "docker"

--- a/Formula/gusto-lima.rb
+++ b/Formula/gusto-lima.rb
@@ -2,29 +2,20 @@ class GustoLima < Formula
   desc "Gusto's opinionated colima profile"
   homepage "https://github.com/abiosoft/colima/blob/main/README.md"
   url "https://github.com/abiosoft/colima.git",
-      tag:      "v0.6.8",
-      revision: "9b0809d0ed9ad3ff1e57c405f27324e6298ca04f"
+      tag:      "v0.1.0",
   license "MIT"
   head "https://github.com/abiosoft/colima.git", branch: "main"
-  
-  depends_on "go" => :build
+
+  depends_on "colima"
   depends_on "docker"
   depends_on "docker-buildx"
   depends_on "docker-compose"
   depends_on "docker-credential-helper"
   depends_on "docker-credential-helper-ecr"
-  depends_on "lima"
 
   def install
-    project = "github.com/abiosoft/colima"
-    ldflags = %W[
-      -s -w
-      -X #{project}/config.appVersion=#{version}
-      -X #{project}/config.revision=#{Utils.git_head}
-    ]
-    system "go", "build", *std_go_args(ldflags:), "./cmd/colima"
 
-    bin.install_symlink bin/"gusto-lima" => bin/"colima"
+    bin.install_symlink bin/"colima" => bin/"gusto_lima"
 
     gusto_profile_config = <<~YAML
       cpu: 4
@@ -57,7 +48,7 @@ class GustoLima < Formula
       mounts: []
       env: {}
     YAML
-    # Create a gusto colima profile
+
     colima_profile_path = Pathname.new(Dir.home)/".colima/gusto"
     colima_profile_path.mkpath
     File.write(colima_profile_path/"colima.yaml", gusto_profile_config)

--- a/Formula/gusto-lima.rb
+++ b/Formula/gusto-lima.rb
@@ -1,0 +1,78 @@
+class GustoLima < Formula
+  desc "Gusto's opinionated colima profile"
+  homepage "https://github.com/abiosoft/colima/blob/main/README.md"
+  url "https://github.com/abiosoft/colima.git",
+      tag:      "v0.6.8",
+      revision: "9b0809d0ed9ad3ff1e57c405f27324e6298ca04f"
+  license "MIT"
+  head "https://github.com/abiosoft/colima.git", branch: "main"
+  
+  depends_on "go" => :build
+  depends_on "docker"
+  depends_on "docker-buildx"
+  depends_on "docker-compose"
+  depends_on "docker-credential-helper"
+  depends_on "docker-credential-helper-ecr"
+  depends_on "lima"
+
+  def install
+    project = "github.com/abiosoft/colima"
+    ldflags = %W[
+      -s -w
+      -X #{project}/config.appVersion=#{version}
+      -X #{project}/config.revision=#{Utils.git_head}
+    ]
+    system "go", "build", *std_go_args(ldflags:), "./cmd/colima"
+
+    bin.install_symlink opt_bin/"colima" => "colima@0.6.8"
+    gusto_profile_config = <<~YAML
+      cpu: 4
+      disk: 60
+      memory: 8
+      arch: host
+      runtime: docker
+      hostname: ""
+      kubernetes:
+      enabled: false
+      version: v1.24.3+k3s1
+      k3sArgs:
+        - --disable=traefik
+      autoActivate: true
+      network:
+      address: false
+      dnsHosts:
+        host.docker.internal: host.lima.internal
+      forwardAgent: false
+      docker: {}
+      vmType: vz
+      rosetta: false
+      mountType: virtiofs
+      mountInotify: false
+      cpuType: host
+      provision:
+        - mode: system
+          script: sysctl -w vm.max_map_count=262144
+      sshConfig: true
+      mounts: []
+      env: {}
+    YAML
+    # Create a gusto colima profile
+    colima_profile_path = Pathname.new(Dir.home)/".colima/gusto"
+    colima_profile_path.mkpath
+    File.write(colima_profile_path/"colima.yaml", gusto_profile_config)
+  end
+
+  service do
+    run [opt_bin/"colima@0.6.8", "start", "-f", "gusto"]
+    keep_alive successful_exit: true
+    environment_variables PATH: std_service_path_env
+    error_log_path var/"log/gusto.log"
+    log_path var/"log/gusto.log"
+    working_dir Dir.home
+  end
+
+  test do
+    assert_match version.to_s, shell_output("#{bin}/colima@0.6.8 version 2>&1")
+    assert_match "colima@0.6.8 is not running", shell_output("#{bin}/colima@0.6.8 status 2>&1", 1)
+  end
+end

--- a/Formula/gusto-lima.rb
+++ b/Formula/gusto-lima.rb
@@ -1,8 +1,7 @@
 class GustoLima < Formula
   desc "Gusto's opinionated colima profile"
   homepage "https://github.com/abiosoft/colima/blob/main/README.md"
-  url "https://github.com/abiosoft/colima.git",
-    tag:      "v0.1.0"
+  url "https://github.com/abiosoft/colima.git", tag: "v0.1.0"
   license "MIT"
   head "https://github.com/abiosoft/colima.git", branch: "main"
 

--- a/Formula/gusto-lima.rb
+++ b/Formula/gusto-lima.rb
@@ -1,12 +1,11 @@
 class GustoLima < Formula
-  desc "Gusto's opinionated colima profile"
+  desc "Gusto's Colima Brew Service"
   homepage "https://github.com/abiosoft/colima/blob/main/README.md"
-  url "https://github.com/gusto/homebrew-gusto.git"
-  sha256 "6df73ae5c606c298d91fcb4f6aa6b3b451082c4a"
+  url "https://github.com/abiosoft/colima.git", tag: "v0.6.8"
 
   depends_on "colima"
   depends_on "docker"
-  depends_on "docker-buildx" 
+  depends_on "docker-buildx"
   depends_on "docker-compose"
   depends_on "docker-credential-helper"
   depends_on "docker-credential-helper-ecr"

--- a/Formula/gusto-lima.rb
+++ b/Formula/gusto-lima.rb
@@ -1,7 +1,8 @@
 class GustoLima < Formula
   desc "Gusto's Colima Brew Service"
   homepage "https://github.com/abiosoft/colima/blob/main/README.md"
-  url "https://github.com/abiosoft/colima.git", tag: "v0.1.1"
+  url "https://github.com/gusto/homebrew-gusto.git", branch: "main"
+  version "0.1.0" 
 
   depends_on "colima"
   depends_on "docker"

--- a/Formula/gusto-lima.rb
+++ b/Formula/gusto-lima.rb
@@ -1,9 +1,7 @@
 class GustoLima < Formula
-  desc "Gusto's opinionated colima profile"
+  desc "Gusto's Colima Brew Service"
   homepage "https://github.com/abiosoft/colima/blob/main/README.md"
-  url "https://github.com/abiosoft/colima.git", tag: "v0.1.0"
-  license "MIT"
-  head "https://github.com/abiosoft/colima.git", branch: "main"
+  url "https://github.com/gusto/homebrew-gusto.git", tag: "v0.1.0"
 
   depends_on "colima"
   depends_on "docker"
@@ -13,7 +11,7 @@ class GustoLima < Formula
   depends_on "docker-credential-helper-ecr"
 
   def install
-    bin.install "colima" => "gusto-lima"
+    bin.install_symlink Formula["colima"].bin/"colima" => "gusto-lima"
   end
 
   service do

--- a/Formula/gusto-lima.rb
+++ b/Formula/gusto-lima.rb
@@ -15,7 +15,7 @@ class GustoLima < Formula
 
   def install
 
-    bin.install_symlink bin/"colima" => bin/"gusto_lima"
+    bin.install_symlink "/opt/homebrew/opt/colima/bin/colima" => "gusto-lima"
 
     gusto_profile_config = <<~YAML
       cpu: 4


### PR DESCRIPTION
# Context 
We want to provide users a Gusto owned brew service that will run the Gusto owned colima profile.

# Test
## colima running
```
> colima list
PROFILE    STATUS     ARCH       CPUS    MEMORY    DISK     RUNTIME    ADDRESS
default    Running    aarch64    4       8GiB      60GiB    docker
```
```
> brew install gusto-lima
> brew services start gusto-lima
```
```
> colima list
PROFILE    STATUS     ARCH       CPUS    MEMORY    DISK     RUNTIME    ADDRESS
default    Running    aarch64    4       8GiB      60GiB    docker
gusto      Running    aarch64    4       8GiB      60GiB    docker
```
```
> docker context list
NAME              DESCRIPTION                               DOCKER ENDPOINT                                                    ERROR
colima            colima                                    unix:///Users/nicolas.larafonseca/.colima/default/docker.sock
colima-gusto *    colima [profile=gusto]                    unix:///Users/nicolas.larafonseca/.colima/gusto/docker.sock
default           Current DOCKER_HOST based configuration   unix:///var/run/docker.sock
```
## colima not installed test
```
colima --version 
The program 'colima' is currently not installed. You can install it by typing:
  brew install colima
```
install gusto-lima
```
> brew install gusto-lima
```
installs colima
```
> colima --version
colima version 0.6.8
```
## colima service is already running 
```
> brew services start colima
==> Successfully started `colima` (label: homebrew.mxcl.colima)

> docker context show
colima
```
start gusto service
```
> brew services start gusto-lima
==> Successfully started `gusto-lima` (label: homebrew.mxcl.colima)
``` 
context is switched to gusto profile
```
> docker context show
colima-gusto
```
Default profile still exists
```
> colima list
PROFILE    STATUS     ARCH       CPUS    MEMORY    DISK     RUNTIME    ADDRESS
default    Running    aarch64    4       10GiB     60GiB    docker
gusto      Running    aarch64    4       8GiB      60GiB    docker
```
Stopping the default service will be done in using scope

