### PR TITLE
Use bash script for gusto-lima install

### DIFF
--- a/Formula/gusto-lima.rb
+++ b/Formula/gusto-lima.rb
@@ -35,6 +35,6 @@ class GustoLima < Formula
   end
 
   test do
-    assert_match "colima is not running", shell_output("#{bin}/gusto-lima status 2>&1", 1)
+    assert_match "colima [profile=gusto] is not running", shell_output("#{bin}/gusto-lima status 2>&1", 1)
   end
 end

--- a/Formula/gusto-lima.rb
+++ b/Formula/gusto-lima.rb
@@ -2,7 +2,7 @@ class GustoLima < Formula
   desc "Gusto's Colima Brew Service"
   homepage "https://github.com/abiosoft/colima/blob/main/README.md"
   url "https://github.com/gusto/homebrew-gusto.git", branch: "main"
-  version "0.1.0"
+  version "0.1.1"
 
   depends_on "colima"
   depends_on "docker"
@@ -12,11 +12,21 @@ class GustoLima < Formula
   depends_on "docker-credential-helper-ecr"
 
   def install
-    bin.install_symlink Formula["colima"].bin/"colima" => "gusto-lima"
+    gusto_colima_script = Tempfile.new(["colima_gusto", ".sh"])
+    gusto_colima_script.write <<~SCRIPT
+      #!/bin/bash
+      colima -p gusto $@
+    SCRIPT
+
+    gusto_colima_script.chmod(0755)
+
+    bin.install gusto_colima_script.path => "gusto-lima"
+
+    gusto_colima_script.unlink
   end
 
   service do
-    run [opt_bin/"gusto-lima", "start", "-f", "gusto"]
+    run [opt_bin/"gusto-lima", "start", "-f"]
     keep_alive successful_exit: true
     environment_variables PATH: std_service_path_env
     error_log_path var/"log/gusto.log"

--- a/Formula/gusto-lima.rb
+++ b/Formula/gusto-lima.rb
@@ -15,7 +15,7 @@ class GustoLima < Formula
     gusto_colima_script = Tempfile.new(["colima_gusto", ".sh"])
     gusto_colima_script.write <<~SCRIPT
       #!/bin/bash
-      colima -p gusto $@
+      exec colima -p gusto "$@"
     SCRIPT
 
     gusto_colima_script.chmod(0755)


### PR DESCRIPTION
# context
The colima symlink was causing issues when colima was upgraded.  

# tests
upgrade gusto-lima
```
> brew install gusto-lima
gusto-lima 0.1.0 is already installed but outdated (so it will be upgraded).
==> Fetching gusto/gustotest/gusto-lima
==> Cloning https://github.com/gusto/homebrew-gusto.git
Updating /Users/nicolas.larafonseca/Library/Caches/Homebrew/gusto-lima--git
==> Checking out branch main
Already on 'main'
Your branch is up to date with 'origin/main'.
HEAD is now at 9b4c3c8 Merge pull request #26 from Gusto/re--gusto-lima
==> Upgrading gusto/gustotest/gusto-lima
  0.1.0 -> 0.1.1
==> Caveats
To start gusto/gustotest/gusto-lima now and restart at login:
  brew services start gusto/gustotest/gusto-lima
Or, if you don't want/need a background service you can just run:
  /opt/homebrew/opt/gusto-lima/bin/gusto-lima start -f
==> Summary
🍺  /opt/homebrew/Cellar/gusto-lima/0.1.1: 8 files, 57.5KB, built in 2 seconds
==> Running `brew cleanup gusto-lima`...
Disable this behaviour by setting HOMEBREW_NO_INSTALL_CLEANUP.
Hide these hints with HOMEBREW_NO_ENV_HINTS (see `man brew`).
Removing: /opt/homebrew/Cellar/gusto-lima/0.1.0... (8 files, 57.7KB)
```
check status
```
> brew services restart gusto-lima
Stopping `gusto-lima`... (might take a while)
==> Successfully stopped `gusto-lima` (label: homebrew.mxcl.gusto-lima)
==> Successfully started `gusto-lima` (label: homebrew.mxcl.gusto-lima)

> gusto-lima status
INFO[0000] colima [profile=gusto] is running using macOS Virtualization.Framework
INFO[0000] arch: aarch64
INFO[0000] runtime: docker
INFO[0000] mountType: virtiofs
INFO[0000] socket: unix:///Users/nicolas.larafonseca/.colima/gusto/docker.sock
```